### PR TITLE
Add Landing Page

### DIFF
--- a/myresumebuilder/myresumebuildersite/urls.py
+++ b/myresumebuilder/myresumebuildersite/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from resumebuilder import views
 
 urlpatterns = [
+    path("", views.landing_page, name="landing_page"),
     path("resumebuilder/", include("resumebuilder.urls")),
     path('admin/', admin.site.urls),
 ]

--- a/myresumebuilder/resumebuilder/templates/resumebuilder/landing_page.html
+++ b/myresumebuilder/resumebuilder/templates/resumebuilder/landing_page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Welcome to My Resume Builder</title>
+</head>
+<body>
+    <h1>Welcome to My Resume Builder</h1>
+    <p>Start building your resume now!</p>
+    <a href="/resumebuilder/">Go to Resume Builder</a>
+</body>
+</html>

--- a/myresumebuilder/resumebuilder/tests.py
+++ b/myresumebuilder/resumebuilder/tests.py
@@ -41,3 +41,21 @@ class ViewsTestCase(TestCase):
         response = self.client.get(reverse("index"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"Hello, world. You're at the resume builder index.")
+
+class LandingPageViewTest(TestCase):
+    def test_landing_page_status_code(self):
+        """Test if the landing page returns a 200 status code."""
+        response = self.client.get(reverse('landing_page'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_landing_page_template(self):
+        """Test if the correct template is used for the landing page."""
+        response = self.client.get(reverse('landing_page'))
+        self.assertTemplateUsed(response, 'resumebuilder/landing_page.html')
+
+    def test_landing_page_content(self):
+        """Test if the landing page contains specific content."""
+        response = self.client.get(reverse('landing_page'))
+        self.assertContains(response, 'Welcome to My Resume Builder')
+        self.assertContains(response, 'Start building your resume now!')
+        self.assertContains(response, 'Go to Resume Builder')

--- a/myresumebuilder/resumebuilder/views.py
+++ b/myresumebuilder/resumebuilder/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
 from django.http import HttpResponse
 
+def landing_page(request):
+    return render(request, "resumebuilder/landing_page.html")
 
 def index(request):
     return HttpResponse("Hello, world. You're at the resume builder index.")


### PR DESCRIPTION
- Configured the root URL (http://localhost:8000/) to serve as the landing page.
- Implemented a `landing_page` view in `resumebuilder/views.py`.
- Added a `landing_page.html` template to the `templates/resumebuilder` directory.
- Added unit tests in `resumebuilder/tests.py` to validate the landing page